### PR TITLE
Set default assignments ordering by difficulty

### DIFF
--- a/rmotr_sis/assignments/models.py
+++ b/rmotr_sis/assignments/models.py
@@ -23,6 +23,9 @@ class Assignment(TimeStampedModel):
 
     tags = TaggableManager()
 
+    class Meta:
+        ordering = ['difficulty']
+
     def __str__(self):
         return self.title
 

--- a/rmotr_sis/courses/models.py
+++ b/rmotr_sis/courses/models.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from django.db import models
 from django.utils import timezone
 
@@ -56,11 +58,11 @@ class Lecture(TimeStampedModel):
         """"Returns all assignments per student with the current
             assignment status.
         """
-        summary = {}
+        summary = OrderedDict()
         students = self.course_instance.students.all()
         assignments = self.assignments.all()
         for student in students:
-            summary.setdefault(student, {})
+            summary.setdefault(student, OrderedDict())
             for a in assignments:
                 summary[student][a] = a.get_status(student)
         return summary


### PR DESCRIPTION
Solves https://github.com/rmotr/rmotr-sis/issues/30

As we have ManyToMany relationship between Lecture and Assignment models, it's not that easy to set a custom ordering to each assignment object. In replacement, as an initial improvement we can sort them by difficulty.